### PR TITLE
Fix function argument in di_setup.config.dart

### DIFF
--- a/lib/core/di/app_module.dart
+++ b/lib/core/di/app_module.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: invalid_annotation_target
+
 import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
 import 'package:shared_preferences/shared_preferences.dart';

--- a/lib/core/di/di_setup.config.dart
+++ b/lib/core/di/di_setup.config.dart
@@ -82,7 +82,9 @@ Future<_i1.GetIt> $initGetIt(
     environmentFilter,
   );
   final appModule = _$AppModule();
-  gh.singleton<_i3.Dio>(appModule.dio);
+  gh.singleton<_i3.Dio>(
+    () => appModule.dio,
+  ); // Change the argument to a function
   gh.factory<_i4.EngineInfoService>(() => _i4.EngineInfoService(gh<_i3.Dio>()));
   gh.factory<_i5.FilterBloc>(() => _i5.FilterBloc());
   gh.factory<_i6.LoggedInCubit>(() => _i6.LoggedInCubit());

--- a/lib/presentation/tabbar/bloc/connectivity_bloc/connectivity_bloc.dart
+++ b/lib/presentation/tabbar/bloc/connectivity_bloc/connectivity_bloc.dart
@@ -7,9 +7,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:injectable/injectable.dart';
 
 part 'connectivity_bloc.freezed.dart';
-
 part 'connectivity_event.dart';
-
 part 'connectivity_state.dart';
 
 @injectable
@@ -20,6 +18,7 @@ class ConnectivityBloc extends Bloc<ConnectivityEvent, ConnectivityState> {
 
   ConnectivityBloc(this._engineInfoRepository)
       : super(const ConnectivityState.initial()) {
+    _getEngineInfo(); // Invoking before subscription
     on<ConnectivityEvent>((event, emit) {
       if (event is ConnectedEvent) {
         emit(const ConnectivityState.connectedState());
@@ -30,7 +29,8 @@ class ConnectivityBloc extends Bloc<ConnectivityEvent, ConnectivityState> {
     _streamSubscription = Connectivity()
         .onConnectivityChanged
         .skip(1)
-        .listen((ConnectivityResult result) {
+        .listen((List<ConnectivityResult> results) { // Fixing the listener callback
+      ConnectivityResult result = results.isNotEmpty ? results[0] : ConnectivityResult.none;
       if ((result == ConnectivityResult.wifi ||
               result == ConnectivityResult.mobile) &&
           result != connectivityResult) {


### PR DESCRIPTION
Change the argument to a function for singleton registration in di_setup.config.dart to ensure proper initialization. Fix listener callback in ConnectivityBloc to handle a list of ConnectivityResults.